### PR TITLE
Update org profile README to match the main repository

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,8 +1,9 @@
 <p align="center">
-  <img src="https://github.com/user-attachments/assets/ff43ca6a-ffde-4aff-9ff9-eec3897d0d02" alt="Rhesis AI Logo" height="80">
+  <img src="https://raw.githubusercontent.com/rhesis-ai/rhesis/main/.github/images/GH-collaborate.png"
+       loading="lazy"
+       width="1920"
+       alt="Rhesis: Get the feedback you need to improve your agents">
 </p>
-
-# Rhesis: Collaborative Testing for LLM & Agentic Applications
 
 <p align="center">
   <a href="https://github.com/rhesis-ai/rhesis/blob/main/LICENSE">
@@ -38,70 +39,114 @@
   <a href="https://github.com/rhesis-ai/rhesis/blob/main/CHANGELOG.md"><strong>Changelog</strong></a>
 </p>
 
-<h3 align="center">More than just evals.<br><strong>Collaborative agent testing for teams.</strong></h3>
+<h3 align="center">Structured feedback and evals for AI agents.<br>
+<strong>Open source · SaaS or self-hosted · UI, SDK, and MCP</strong></h3>
 
 <p align="center">
-Generate tests from requirements, simulate conversation flows, detect adversarial behaviors, evaluate with 60+ metrics, and trace failures with OpenTelemetry. Engineers and domain experts, working together.
-</p>
-
-<p align="center">
-  <a href="https://rhesis.ai/?video=open" target="_blank">
-    <img src="https://raw.githubusercontent.com/rhesis-ai/rhesis/main/.github/images/GH_Short_Demo.png"
-         loading="lazy"
-         width="1080"
-         alt="Rhesis Platform Overview - Click to watch demo">
-  </a>
+Connect the agent you are building, share the link with your team, and get structured feedback from the people who know the right answers.
 </p>
 
 ---
 
-## What Rhesis does
+## Why Rhesis?
+
+Most tools start with tests or traces. Rhesis starts one step earlier: the people who know what the
+agent should answer are not the people building it, and their feedback rarely arrives in a form you
+can act on.
+
+- **Feedback that stays attached** — Every review sits on the test case and the agent version that produced it, not in a Slack thread
+- **One pass/fail bar** — The whole team reviews against the same tests, and you measure against them
+- **UI for reviewers, SDK and MCP for builders** — Same data, three ways in
+- **From feedback to CI** — Recurring feedback becomes tests and metrics that run on every change
+
+---
+
+## How it works
+
+**1. Connect the agent you are building.** Paste a public REST URL, or use the SDK connector — your
+process opens an outbound WebSocket, so the agent works from your laptop or your VPC with no public
+URL.
+
+**2. Share the Rhesis link with your stakeholders.** Domain experts, product managers, and
+reviewers open it in a browser. Nothing to install, no code.
+
+**3. They put the agent to work.** They chat with the live agent in the playground, turn interesting
+conversations into tests, run test sets, and leave pass/fail verdicts and comments down to the
+individual metric or conversation turn.
+
+**4. Pull that feedback back into development.** Read it from the SDK or REST API, or work with it
+from Cursor, Claude Code, and other MCP clients. Fix the agent, run the same tests again.
+
+**5. Agree on what the agent has to get right.** Each cycle, feedback that arrived as prose becomes
+tests and metrics that check the same thing automatically.
+
+---
+
+## Who it’s for
+
+| Role | How they use Rhesis |
+|------|---------------------|
+| **AI engineers** | Connect the agent, pull feedback and reviewed test sets into the SDK, CI, and MCP while you build |
+| **Domain experts** | Try the agent, review its answers, say what is wrong and what a correct answer looks like. UI, no code |
+| **Product managers** | Turn scattered feedback into tests, and see whether the agent improves against the PRD. UI or MCP |
+
+---
+
+## Capabilities
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/rhesis-ai/rhesis/main/.github/images/GH_Features.png"
+  <img src="https://raw.githubusercontent.com/rhesis-ai/rhesis/main/.github/images/GH-capabilities.png"
        loading="lazy"
-       width="1080"
-       alt="Rhesis Core Features">
+       width="1920"
+       alt="Start with the feedback you already have and expand from there — review test results, inspect annotations, gain insights">
 </p>
 
-| | |
-|---|---|
-| **Test generation** | Describe requirements in plain language. Rhesis generates hundreds of test scenarios, including edge cases and adversarial prompts, from your connected context sources. |
-| **Conversation simulation** | **Penelope** runs realistic multi-turn dialogues to test context retention, role adherence, and coherence across extended interactions. |
-| **Adversarial testing** | **Polyphemus** and [garak](https://github.com/leondz/garak) probe for jailbreaks, prompt injection, PII leakage, and harmful content generation. |
-| **60+ pre-built metrics** | RAGAS, DeepEval, and Garak metrics, plus custom LLM-as-Judge evaluations — all with reasoning explanations. |
-| **Traces & observability** | OpenTelemetry-based tracing, with automatic instrumentation for LangChain, LangGraph, Microsoft Agent Framework, and OpenInference frameworks. |
-| **Bring your own model** | Any provider through [LiteLLM](https://github.com/BerriAI/litellm) — OpenAI, Anthropic, Gemini, Mistral, Ollama, vLLM, and 100+ more. |
+Nobody can review every case by hand. Once the first feedback is in, you can grow coverage from it:
 
-Testing shouldn't be limited to engineers. Legal teams understand compliance requirements, marketing knows the brand guidelines, and domain experts spot the edge cases. Rhesis lets everyone contribute their expertise without writing code, then turns it into automated test runs via UI, SDK, or CI/CD.
+- **Test generation** from your requirements, a PRD, or an uploaded file
+- **Conversation simulation** with Penelope; **adversarial probing** with Polyphemus and [garak](https://github.com/leondz/garak)
+- **60+ metrics** — RAGAS, DeepEval, garak, and custom LLM-as-Judge evaluators
+- **Traces** linked to test results via OpenTelemetry
+
+Generated tests are only as good as the requirements behind them, so connect the tools your
+requirements already live in — Notion, GitHub, Jira, Confluence — and Rhesis writes tests from the
+real thing. See [Tools](https://docs.rhesis.ai/docs/tools).
 
 ---
 
 ## Get started
 
-**Cloud** — [app.rhesis.ai](https://app.rhesis.ai). Managed service, just connect your app.
+### Cloud
 
-**Self-hosted** — Docker, in about five minutes:
+[app.rhesis.ai](https://app.rhesis.ai) — managed service, connect your agent and invite your team.
+
+### Local (Docker)
 
 ```bash
 git clone https://github.com/rhesis-ai/rhesis.git && cd rhesis && ./rh start
 ```
 
-**Python SDK** — code-first testing inside your own pipeline:
+Frontend at `localhost:3000`, API at `localhost:8080/docs`. For production self-hosting, see the
+[deployment docs](https://docs.rhesis.ai/docs/deployment).
+
+### From your own tools
 
 ```bash
-pip install rhesis-sdk
+pip install rhesis-sdk              # Python SDK: connector, synthesizers, metrics, tracing
+npx skills add rhesis-ai/rhesis     # MCP and skills for Cursor, Claude Code, and others
 ```
 
-Everything lives in the [rhesis monorepo](https://github.com/rhesis-ai/rhesis); full guides are in the [documentation](https://docs.rhesis.ai).
+Everything lives in the [rhesis monorepo](https://github.com/rhesis-ai/rhesis); full guides are in
+the [documentation](https://docs.rhesis.ai).
 
 ---
 
 ## Open source
 
-[MIT licensed](https://github.com/rhesis-ai/rhesis/blob/main/LICENSE), with no plans to relicense core features. The enterprise edition lives in separate `ee/` folders.
+[MIT licensed](https://github.com/rhesis-ai/rhesis/blob/main/LICENSE). No plans to relicense core features. Enterprise features live in `ee/` and remain separate.
 
-We built Rhesis because existing LLM testing tools didn't meet our needs for testing agentic applications. If you face the same challenges, [contributions](https://github.com/rhesis-ai/rhesis/blob/main/CONTRIBUTING.md) are welcome.
+We built Rhesis because the feedback that mattered most kept getting stuck outside the development
+loop. If you face the same problem, [contributions](https://github.com/rhesis-ai/rhesis/blob/main/CONTRIBUTING.md) are welcome.
 
 ---
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -55,37 +55,55 @@ Generate tests from requirements, simulate conversation flows, detect adversaria
 
 ---
 
-## About Rhesis AI
+## What Rhesis does
 
-### Built by developers who needed better LLM testing tools
+<p align="center">
+  <img src="https://raw.githubusercontent.com/rhesis-ai/rhesis/main/.github/images/GH_Features.png"
+       loading="lazy"
+       width="1080"
+       alt="Rhesis Core Features">
+</p>
 
-We built Rhesis because existing LLM testing tools didn't meet our needs for testing agentic applications. If you face the same challenges, contributions are welcome.
+| | |
+|---|---|
+| **Test generation** | Describe requirements in plain language. Rhesis generates hundreds of test scenarios, including edge cases and adversarial prompts, from your connected context sources. |
+| **Conversation simulation** | **Penelope** runs realistic multi-turn dialogues to test context retention, role adherence, and coherence across extended interactions. |
+| **Adversarial testing** | **Polyphemus** and [garak](https://github.com/leondz/garak) probe for jailbreaks, prompt injection, PII leakage, and harmful content generation. |
+| **60+ pre-built metrics** | RAGAS, DeepEval, and Garak metrics, plus custom LLM-as-Judge evaluations — all with reasoning explanations. |
+| **Traces & observability** | OpenTelemetry-based tracing, with automatic instrumentation for LangChain, LangGraph, Microsoft Agent Framework, and OpenInference frameworks. |
+| **Bring your own model** | Any provider through [LiteLLM](https://github.com/BerriAI/litellm) — OpenAI, Anthropic, Gemini, Mistral, Ollama, vLLM, and 100+ more. |
 
-### Collaborative testing for cross-functional teams
-
-Testing shouldn't be limited to engineers. Legal teams understand compliance requirements. Marketing knows brand guidelines. Domain experts identify edge cases. Rhesis enables everyone to contribute their expertise without writing code.
-
-### From requirements to automated test execution
-
-Define requirements in plain language. Rhesis generates test scenarios based on your team's collective knowledge. Execute tests automatically via UI, SDK, or CI/CD. Get detailed results showing exactly how your LLM & agentic applications perform.
-
-### Open source with a clear license model
-
-[MIT licensed](https://github.com/rhesis-ai/rhesis/blob/main/LICENSE). Enterprise version lives in `ee/` folders and remain separate.
+Testing shouldn't be limited to engineers. Legal teams understand compliance requirements, marketing knows the brand guidelines, and domain experts spot the edge cases. Rhesis lets everyone contribute their expertise without writing code, then turns it into automated test runs via UI, SDK, or CI/CD.
 
 ---
 
 ## Get started
 
-Check out our [main repository](https://github.com/rhesis-ai/rhesis) and [documentation](https://docs.rhesis.ai) to get started.
+**Cloud** — [app.rhesis.ai](https://app.rhesis.ai). Managed service, just connect your app.
 
-**Quick start options:**
+**Self-hosted** — Docker, in about five minutes:
 
-- **Cloud** - [app.rhesis.ai](https://app.rhesis.ai) - Managed service, just connect your app
-- **Self-hosted** - Run locally with Docker in 5 minutes
-- **Python SDK** - Integrate directly into your codebase
+```bash
+git clone https://github.com/rhesis-ai/rhesis.git && cd rhesis && ./rh start
+```
 
---- 
+**Python SDK** — code-first testing inside your own pipeline:
+
+```bash
+pip install rhesis-sdk
+```
+
+Everything lives in the [rhesis monorepo](https://github.com/rhesis-ai/rhesis); full guides are in the [documentation](https://docs.rhesis.ai).
+
+---
+
+## Open source
+
+[MIT licensed](https://github.com/rhesis-ai/rhesis/blob/main/LICENSE), with no plans to relicense core features. The enterprise edition lives in separate `ee/` folders.
+
+We built Rhesis because existing LLM testing tools didn't meet our needs for testing agentic applications. If you face the same challenges, [contributions](https://github.com/rhesis-ai/rhesis/blob/main/CONTRIBUTING.md) are welcome.
+
+---
 
 ## Funding acknowledgment
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -118,7 +118,7 @@ real thing. See [Tools](https://docs.rhesis.ai/docs/tools).
 
 ### Cloud
 
-[app.rhesis.ai](https://app.rhesis.ai) — managed service, connect your agent and invite your team.
+[app.rhesis.ai](https://app.rhesis.ai) — experience Rhesis in the browser, with nothing to set up.
 
 ### Local (Docker)
 


### PR DESCRIPTION
## Purpose

The org profile landing page at https://github.com/rhesis-ai still carried the old "Collaborative Testing for LLM & Agentic Applications" positioning. The main repository README has since been redesigned around feedback first: a wide banner instead of a title, a new tagline, and the "connect the agent, share the link, get structured feedback" story.

This brings the profile in line with `rhesis-ai/rhesis/README.md` as it stands on `main`, while keeping it a landing page rather than a full README (173 lines against the main README's ~310).

## What Changed

- **Head banner** — `GH-collaborate.png` at the top, replacing the small logo and the `# Rhesis: Collaborative Testing for LLM & Agentic Applications` heading. The main README has no H1 either; the banner carries it.
- **New tagline and lede** — "Structured feedback and evals for AI agents. Open source · SaaS or self-hosted · UI, SDK, and MCP", followed by the "connect the agent you are building, share the link with your team" line. The old "More than just evals" / "Generate tests from requirements…" copy is gone.
- **Removed the YouTube demo thumbnail** — no video embed on the profile.
- **New body sections** mirroring the main README, condensed: Why Rhesis (the four feedback bullets), How it works (five steps), Who it's for (role table), and Capabilities (with `GH-capabilities.png`, plus the requirements-tools note).
- **Get started** — Cloud, local Docker via `./rh start`, and a "from your own tools" block with `pip install rhesis-sdk` and `npx skills add rhesis-ai/rhesis`.
- **Open source** — updated to the current wording, including the "feedback that mattered most kept getting stuck outside the development loop" line, and links `CONTRIBUTING.md`.
- Badges and nav links unchanged. Images use absolute `raw.githubusercontent.com` URLs, since relative repo paths do not resolve when rendered on the org profile.
- **Funding acknowledgment** (BMFTR / StartUpSecure) and the Potsdam footer preserved verbatim.

Left out of the landing version deliberately: the connector deep dive, MCP/SDK/REST detail, the deployment matrix, the "In this repo" table, contributing, support, and the telemetry/security section. Those stay in the main repository README.

## Additional Context

- Source of truth: https://github.com/rhesis-ai/rhesis/blob/main/README.md
- No changes outside `profile/README.md`.
- All three remote images return 200: `GH-collaborate.png`, `GH-capabilities.png`, and the BMFTR logo. The first commit on this branch referenced `GH_Features.png`, which does not exist on `main` and 404s; the second commit removes it.

## Testing

Review the rendered diff in the Files changed tab. After merge, confirm https://github.com/rhesis-ai renders correctly and that the banner, capabilities image, and BMFTR logo all load.